### PR TITLE
Reuse reference format between message types

### DIFF
--- a/build_schema.sh
+++ b/build_schema.sh
@@ -18,3 +18,4 @@ YAMLTOJSON < schema/se/PrivateUnsecuredLoanStatusUpdated.yaml > schema/se/Privat
 YAMLTOJSON < schema/se/PrivateUnsecuredLoanRejection.yaml > schema/se/PrivateUnsecuredLoanRejection.json
 YAMLTOJSON < schema/se/PrivateUnsecuredLoanDelayedProcessing.yaml > schema/se/PrivateUnsecuredLoanDelayedProcessing.json
 YAMLTOJSON < schema/se/PrivateUnsecuredLoanOffering.yaml > schema/se/PrivateUnsecuredLoanOffering.json
+YAMLTOJSON < schema/se/reference.yaml > schema/se/reference.json

--- a/schema-docs/PrivateUnsecuredLoanApplicationCreated.md
+++ b/schema-docs/PrivateUnsecuredLoanApplicationCreated.md
@@ -12,14 +12,18 @@ a private unsecure loan.
 | Abstract | Extensible | Status | Identifiable | Custom Properties | Additional Properties | Defined In |
 |----------|------------|--------|--------------|-------------------|-----------------------|------------|
 | Can be instantiated | Yes | Experimental | No | Forbidden | Forbidden | [PrivateUnsecuredLoanApplicationCreated.json](PrivateUnsecuredLoanApplicationCreated.json) |
+## Schema Hierarchy
+
+* PrivateUnsecuredLoanApplicationCreated `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanApplicationCreated`
+  * [reference](reference.md) `https://open-broker.org/schema/v0/se/reference`
+
 
 # PrivateUnsecuredLoanApplicationCreated Properties
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
 | [application](#application) | `object` | **Required** | PrivateUnsecuredLoanApplicationCreated (this schema) |
-| [broker](#broker) | `string` | Optional | PrivateUnsecuredLoanApplicationCreated (this schema) |
-| [brokerReference](#brokerreference) | `string` | Optional | PrivateUnsecuredLoanApplicationCreated (this schema) |
+| [brokerReference](#brokerreference) | reference | **Required** | PrivateUnsecuredLoanApplicationCreated (this schema) |
 | [dataProtectionContext](#dataprotectioncontext) | `enum` | **Required** | PrivateUnsecuredLoanApplicationCreated (this schema) |
 
 ## application
@@ -250,48 +254,18 @@ The number 1-month terms that the applicant desires to pay off the loan over
 
 
 
-## broker
-### Domain-name of the broker, in reverse order
-
-Reversed DNS name for the broker, for example, example.com becomes com.example
-
-`broker`
-* is optional
-* type: `string`
-* defined in this schema
-
-### broker Type
-
-
-`string`
-
-
-All instances must conform to this regular expression 
-(test examples [here](https://regexr.com/?expression=%5E((%5Ba-zA-Z0-9%5D%7C%5Ba-zA-Z0-9%5D%5Ba-zA-Z0-9-%5D%5Ba-zA-Z0-9%5D).)(%5BA-Za-z0-9%5D%7C%5BA-Za-z0-9%5D%5BA-Za-z0-9-%5D*%5BA-Za-z0-9%5D))):
-```regex
-^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])
-```
-
-
-
-
-
-
 ## brokerReference
-### Reference number for the broker
-
-An arbitrary ID specified by the broker
+### A reference-id used by the broker
 
 `brokerReference`
-* is optional
-* type: `string`
+* is **required**
+* type: reference
 * defined in this schema
 
 ### brokerReference Type
 
 
-`string`
-
+* [reference](reference.md) – `https://open-broker.org/schema/v0/se/reference`
 
 
 
@@ -341,7 +315,7 @@ The value of this property **must** be equal to one of the [known values below](
 | [countriesOfResidence](#countriesofresidence) | CountryCodeArray | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanApplicationCreated#/definitions/applicant` |
 | [dependentChildren](#dependentchildren) | `integer` | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanApplicationCreated#/definitions/applicant` |
 | [emailAddress](#emailaddress) | `string` | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanApplicationCreated#/definitions/applicant` |
-| [employer](#employer) | `string` | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanApplicationCreated#/definitions/applicant` |
+| [employerName](#employername) | `string` | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanApplicationCreated#/definitions/applicant` |
 | [employerPhone](#employerphone) | `string` | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanApplicationCreated#/definitions/applicant` |
 | [employmentStatus](#employmentstatus) | `enum` | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanApplicationCreated#/definitions/applicant` |
 | [employmentStatusSinceMonth](#employmentstatussincemonth) | `integer` | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanApplicationCreated#/definitions/applicant` |
@@ -633,15 +607,15 @@ Number of child dependents under the age of 18. If greater than 15 then 15 is se
 
 
 
-## employer
+## employerName
 ### The company name of the employer
 
-`employer`
+`employerName`
 * is optional
 * type: `string`
 * defined in this schema
 
-### employer Type
+### employerName Type
 
 
 `string`
@@ -650,7 +624,7 @@ Number of child dependents under the age of 18. If greater than 15 then 15 is se
 
 
 
-### employer Example
+### employerName Example
 
 ```json
 "ACME AB"

--- a/schema-docs/PrivateUnsecuredLoanDelayedProcessing.md
+++ b/schema-docs/PrivateUnsecuredLoanDelayedProcessing.md
@@ -11,55 +11,31 @@ An event indicating that the application was rejected
 | Abstract | Extensible | Status | Identifiable | Custom Properties | Additional Properties | Defined In |
 |----------|------------|--------|--------------|-------------------|-----------------------|------------|
 | Can be instantiated | No | Experimental | No | Forbidden | Forbidden | [PrivateUnsecuredLoanDelayedProcessing.json](PrivateUnsecuredLoanDelayedProcessing.json) |
+## Schema Hierarchy
+
+* PrivateUnsecuredLoanDelayedProcessing `https://open-broker.org/schema/v0/se/PrivateUnsecuredDelayedProcessing`
+  * [reference](reference.md) `https://open-broker.org/schema/v0/se/reference`
+
 
 # PrivateUnsecuredLoanDelayedProcessing Properties
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
-| [broker](#broker) | `string` | **Required** | PrivateUnsecuredLoanDelayedProcessing (this schema) |
-| [brokerReference](#brokerreference) | `string` | **Required** | PrivateUnsecuredLoanDelayedProcessing (this schema) |
+| [brokerReference](#brokerreference) | reference | **Required** | PrivateUnsecuredLoanDelayedProcessing (this schema) |
 | [delayReason](#delayreason) | `enum` | Optional | PrivateUnsecuredLoanDelayedProcessing (this schema) |
 
-## broker
-### Domain-name of the broker, in reverse order
-
-Reversed DNS name for the broker, for example, example.com becomes com.example
-
-`broker`
-* is **required**
-* type: `string`
-* defined in this schema
-
-### broker Type
-
-
-`string`
-
-
-All instances must conform to this regular expression 
-(test examples [here](https://regexr.com/?expression=%5E((%5Ba-zA-Z0-9%5D%7C%5Ba-zA-Z0-9%5D%5Ba-zA-Z0-9-%5D%5Ba-zA-Z0-9%5D).)(%5BA-Za-z0-9%5D%7C%5BA-Za-z0-9%5D%5BA-Za-z0-9-%5D*%5BA-Za-z0-9%5D))):
-```regex
-^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])
-```
-
-
-
-
-
-
 ## brokerReference
-### Reference number for the broker
+### A reference-id used by the broker
 
 `brokerReference`
 * is **required**
-* type: `string`
+* type: reference
 * defined in this schema
 
 ### brokerReference Type
 
 
-`string`
-* minimum length: 1 characters
+* [reference](reference.md) – `https://open-broker.org/schema/v0/se/reference`
 
 
 
@@ -81,6 +57,7 @@ The value of this property **must** be equal to one of the [known values below](
 | `HOLIDAY` | The application will be processed later because of a holiday |
 | `MANUAL_PROCESSING` | The application is being processed manually |
 | `OPERATIONAL_ISSUES` | The service provider is experiencing operational issues and processing will be delayed. |
+| `OTHER` | The application was delayed for some other reason |
 
 
 

--- a/schema-docs/PrivateUnsecuredLoanDisbursed.md
+++ b/schema-docs/PrivateUnsecuredLoanDisbursed.md
@@ -12,6 +12,11 @@ disbursed
 | Abstract | Extensible | Status | Identifiable | Custom Properties | Additional Properties | Defined In |
 |----------|------------|--------|--------------|-------------------|-----------------------|------------|
 | Can be instantiated | No | Experimental | No | Forbidden | Forbidden | [PrivateUnsecuredLoanDisbursed.json](PrivateUnsecuredLoanDisbursed.json) |
+## Schema Hierarchy
+
+* PrivateUnsecuredLoanDisbursed `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanDisbursed`
+  * [reference](reference.md) `https://open-broker.org/schema/v0/se/reference`
+
 
 # PrivateUnsecuredLoanDisbursed Properties
 
@@ -19,8 +24,7 @@ disbursed
 |----------|------|----------|------------|
 | [amountBrokered](#amountbrokered) | `integer` | **Required** | PrivateUnsecuredLoanDisbursed (this schema) |
 | [amountDisbursed](#amountdisbursed) | `integer` | **Required** | PrivateUnsecuredLoanDisbursed (this schema) |
-| [broker](#broker) | `string` | **Required** | PrivateUnsecuredLoanDisbursed (this schema) |
-| [brokerReference](#brokerreference) | `string` | **Required** | PrivateUnsecuredLoanDisbursed (this schema) |
+| [brokerReference](#brokerreference) | reference | **Required** | PrivateUnsecuredLoanDisbursed (this schema) |
 
 ## amountBrokered
 ### Amount considered brokered by the lender
@@ -69,46 +73,18 @@ the customer of the loan being brokered
 
 
 
-## broker
-### Domain-name of the broker, in reverse order
-
-Reversed DNS name for the broker, for example, example.com becomes com.example
-
-`broker`
-* is **required**
-* type: `string`
-* defined in this schema
-
-### broker Type
-
-
-`string`
-
-
-All instances must conform to this regular expression 
-(test examples [here](https://regexr.com/?expression=%5E((%5Ba-zA-Z0-9%5D%7C%5Ba-zA-Z0-9%5D%5Ba-zA-Z0-9-%5D%5Ba-zA-Z0-9%5D).)(%5BA-Za-z0-9%5D%7C%5BA-Za-z0-9%5D%5BA-Za-z0-9-%5D*%5BA-Za-z0-9%5D))):
-```regex
-^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])
-```
-
-
-
-
-
-
 ## brokerReference
-### Reference number for the broker
+### A reference-id used by the broker
 
 `brokerReference`
 * is **required**
-* type: `string`
+* type: reference
 * defined in this schema
 
 ### brokerReference Type
 
 
-`string`
-* minimum length: 1 characters
+* [reference](reference.md) – `https://open-broker.org/schema/v0/se/reference`
 
 
 

--- a/schema-docs/PrivateUnsecuredLoanOffering.md
+++ b/schema-docs/PrivateUnsecuredLoanOffering.md
@@ -11,55 +11,31 @@ An offer for a loan
 | Abstract | Extensible | Status | Identifiable | Custom Properties | Additional Properties | Defined In |
 |----------|------------|--------|--------------|-------------------|-----------------------|------------|
 | Can be instantiated | Yes | Experimental | No | Forbidden | Forbidden | [PrivateUnsecuredLoanOffering.json](PrivateUnsecuredLoanOffering.json) |
+## Schema Hierarchy
+
+* PrivateUnsecuredLoanOffering `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanOffering`
+  * [reference](reference.md) `https://open-broker.org/schema/v0/se/reference`
+
 
 # PrivateUnsecuredLoanOffering Properties
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
-| [broker](#broker) | `string` | **Required** | PrivateUnsecuredLoanOffering (this schema) |
-| [brokerReference](#brokerreference) | `string` | **Required** | PrivateUnsecuredLoanOffering (this schema) |
+| [brokerReference](#brokerreference) | reference | **Required** | PrivateUnsecuredLoanOffering (this schema) |
 | [offer](#offer) | `object` | **Required** | PrivateUnsecuredLoanOffering (this schema) |
 
-## broker
-### Domain-name of the broker, in reverse order
-
-Reversed DNS name for the broker, for example, example.com becomes com.example
-
-`broker`
-* is **required**
-* type: `string`
-* defined in this schema
-
-### broker Type
-
-
-`string`
-
-
-All instances must conform to this regular expression 
-(test examples [here](https://regexr.com/?expression=%5E((%5Ba-zA-Z0-9%5D%7C%5Ba-zA-Z0-9%5D%5Ba-zA-Z0-9-%5D%5Ba-zA-Z0-9%5D).)(%5BA-Za-z0-9%5D%7C%5BA-Za-z0-9%5D%5BA-Za-z0-9-%5D*%5BA-Za-z0-9%5D))):
-```regex
-^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])
-```
-
-
-
-
-
-
 ## brokerReference
-### Reference number for the broker
+### A reference-id used by the broker
 
 `brokerReference`
 * is **required**
-* type: `string`
+* type: reference
 * defined in this schema
 
 ### brokerReference Type
 
 
-`string`
-* minimum length: 1 characters
+* [reference](reference.md) – `https://open-broker.org/schema/v0/se/reference`
 
 
 
@@ -82,7 +58,7 @@ All instances must conform to this regular expression
 | Property | Type | Required |
 |----------|------|----------|
 | `arrangementFee`| integer | **Required** |
-| `effectiveInterestRate`| string | Optional |
+| `effectiveInterestRate`| string | **Required** |
 | `invoiceFee`| integer | **Required** |
 | `loanInsuranceOffer`|  | Optional |
 | `maxOfferedCredit`| integer | **Required** |
@@ -129,7 +105,7 @@ floating-point numbers.
 
 
 `effectiveInterestRate`
-* is optional
+* is **required**
 * type: `string`
 
 ##### effectiveInterestRate Type
@@ -183,14 +159,8 @@ undefined
 
 ##### loanInsuranceOffer Type
 
-Unknown type ``.
 
-```json
-{
-  "ref": "#/definitions/LoanInsuranceOffer",
-  "simpletype": "`undefined`"
-}
-```
+* []() – `#/definitions/LoanInsuranceOffer`
 
 
 
@@ -403,7 +373,7 @@ the offered interest and offered amount.
 | [effectiveInterestRate](#effectiveinterestrate) | `string` | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanOffering#/definitions/Offer` |
 | [insuredAmount](#insuredamount) | `integer` | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanOffering#/definitions/LoanInsuranceOffer` |
 | [invoiceFee](#invoicefee) | `integer` | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanOffering#/definitions/Offer` |
-| [loanInsuranceOffer](#loaninsuranceoffer) | complex | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanOffering#/definitions/Offer` |
+| [loanInsuranceOffer](#loaninsuranceoffer) | reference | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanOffering#/definitions/Offer` |
 | [maxOfferedCredit](#maxofferedcredit) | `integer` | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanOffering#/definitions/Offer` |
 | [minOfferedCredit](#minofferedcredit) | `integer` | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanOffering#/definitions/Offer` |
 | [monthlyPremium](#monthlypremium) | `integer` | `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanOffering#/definitions/LoanInsuranceOffer` |
@@ -528,20 +498,13 @@ All instances must conform to this regular expression
 
 `loanInsuranceOffer`
 * is optional
-* type: complex
+* type: reference
 * defined in this schema
 
 ### loanInsuranceOffer Type
 
-Unknown type ``.
 
-```json
-{
-  "ref": "#/definitions/LoanInsuranceOffer",
-  "definitiongroup": "Offer",
-  "simpletype": "complex"
-}
-```
+* []() – `#/definitions/LoanInsuranceOffer`
 
 
 

--- a/schema-docs/PrivateUnsecuredLoanRejection.md
+++ b/schema-docs/PrivateUnsecuredLoanRejection.md
@@ -11,54 +11,30 @@ An event indicating that the application was rejected
 | Abstract | Extensible | Status | Identifiable | Custom Properties | Additional Properties | Defined In |
 |----------|------------|--------|--------------|-------------------|-----------------------|------------|
 | Can be instantiated | No | Experimental | No | Forbidden | Forbidden | [PrivateUnsecuredLoanRejection.json](PrivateUnsecuredLoanRejection.json) |
+## Schema Hierarchy
+
+* PrivateUnsecuredLoanRejection `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanRejection`
+  * [reference](reference.md) `https://open-broker.org/schema/v0/se/reference`
+
 
 # PrivateUnsecuredLoanRejection Properties
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
-| [broker](#broker) | `string` | **Required** | PrivateUnsecuredLoanRejection (this schema) |
-| [brokerReference](#brokerreference) | `string` | **Required** | PrivateUnsecuredLoanRejection (this schema) |
-
-## broker
-### Domain-name of the broker, in reverse order
-
-Reversed DNS name for the broker, for example, example.com becomes com.example
-
-`broker`
-* is **required**
-* type: `string`
-* defined in this schema
-
-### broker Type
-
-
-`string`
-
-
-All instances must conform to this regular expression 
-(test examples [here](https://regexr.com/?expression=%5E((%5Ba-zA-Z0-9%5D%7C%5Ba-zA-Z0-9%5D%5Ba-zA-Z0-9-%5D%5Ba-zA-Z0-9%5D).)(%5BA-Za-z0-9%5D%7C%5BA-Za-z0-9%5D%5BA-Za-z0-9-%5D*%5BA-Za-z0-9%5D))):
-```regex
-^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])
-```
-
-
-
-
-
+| [brokerReference](#brokerreference) | reference | **Required** | PrivateUnsecuredLoanRejection (this schema) |
 
 ## brokerReference
-### Reference number for the broker
+### A reference-id used by the broker
 
 `brokerReference`
 * is **required**
-* type: `string`
+* type: reference
 * defined in this schema
 
 ### brokerReference Type
 
 
-`string`
-* minimum length: 1 characters
+* [reference](reference.md) – `https://open-broker.org/schema/v0/se/reference`
 
 
 

--- a/schema-docs/PrivateUnsecuredLoanStatusUpdated.md
+++ b/schema-docs/PrivateUnsecuredLoanStatusUpdated.md
@@ -11,55 +11,31 @@ An event indicating an update to the status of a loan being brokered
 | Abstract | Extensible | Status | Identifiable | Custom Properties | Additional Properties | Defined In |
 |----------|------------|--------|--------------|-------------------|-----------------------|------------|
 | Can be instantiated | No | Experimental | No | Forbidden | Forbidden | [PrivateUnsecuredLoanStatusUpdated.json](PrivateUnsecuredLoanStatusUpdated.json) |
+## Schema Hierarchy
+
+* PrivateUnsecuredLoanStatusUpdated `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanStatusUpdated`
+  * [reference](reference.md) `https://open-broker.org/schema/v0/se/reference`
+
 
 # PrivateUnsecuredLoanStatusUpdated Properties
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
-| [broker](#broker) | `string` | **Required** | PrivateUnsecuredLoanStatusUpdated (this schema) |
-| [brokerReference](#brokerreference) | `string` | **Required** | PrivateUnsecuredLoanStatusUpdated (this schema) |
+| [brokerReference](#brokerreference) | reference | **Required** | PrivateUnsecuredLoanStatusUpdated (this schema) |
 | [status](#status) | `enum` | **Required** | PrivateUnsecuredLoanStatusUpdated (this schema) |
 
-## broker
-### Domain-name of the broker, in reverse order
-
-Reversed DNS name for the broker, for example, example.com becomes com.example
-
-`broker`
-* is **required**
-* type: `string`
-* defined in this schema
-
-### broker Type
-
-
-`string`
-
-
-All instances must conform to this regular expression 
-(test examples [here](https://regexr.com/?expression=%5E((%5Ba-zA-Z0-9%5D%7C%5Ba-zA-Z0-9%5D%5Ba-zA-Z0-9-%5D%5Ba-zA-Z0-9%5D).)(%5BA-Za-z0-9%5D%7C%5BA-Za-z0-9%5D%5BA-Za-z0-9-%5D*%5BA-Za-z0-9%5D))):
-```regex
-^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])
-```
-
-
-
-
-
-
 ## brokerReference
-### Reference number for the broker
+### A reference-id used by the broker
 
 `brokerReference`
 * is **required**
-* type: `string`
+* type: reference
 * defined in this schema
 
 ### brokerReference Type
 
 
-`string`
-* minimum length: 1 characters
+* [reference](reference.md) – `https://open-broker.org/schema/v0/se/reference`
 
 
 

--- a/schema-docs/README.md
+++ b/schema-docs/README.md
@@ -12,4 +12,5 @@
 * [PrivateUnsecuredLoanOffering](./PrivateUnsecuredLoanOffering.json.schema.md) – `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanOffering` (Unknown)
 * [PrivateUnsecuredLoanRejection](./PrivateUnsecuredLoanRejection.json.schema.md) – `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanRejection` (Unknown)
 * [PrivateUnsecuredLoanStatusUpdated](./PrivateUnsecuredLoanStatusUpdated.json.schema.md) – `https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanStatusUpdated` (Unknown)
+* [reference](./reference.json.schema.md) – `https://open-broker.org/schema/v0/se/reference` (Unknown)
 

--- a/schema-docs/reference.md
+++ b/schema-docs/reference.md
@@ -1,0 +1,71 @@
+
+# reference Schema
+
+```
+https://open-broker.org/schema/v0/se/reference
+```
+
+A reference used for identification of an event. Consisting of two
+parts an issuer domain name of the form `com.example`, and an
+arbitrary id string. The values, taken together must be unique.
+
+In other words, the issuing organization can issue an ID once only.
+
+
+| Abstract | Extensible | Status | Identifiable | Custom Properties | Additional Properties | Defined In |
+|----------|------------|--------|--------------|-------------------|-----------------------|------------|
+| Can be instantiated | No | Experimental | No | Forbidden | Forbidden | [reference.json](reference.json) |
+
+# reference Properties
+
+| Property | Type | Required | Defined by |
+|----------|------|----------|------------|
+| [id](#id) | `string` | Optional | reference (this schema) |
+| [issuer](#issuer) | `string` | Optional | reference (this schema) |
+
+## id
+### Reference number for the broker
+
+An arbitrary reference string that is unique
+
+`id`
+* is optional
+* type: `string`
+* defined in this schema
+
+### id Type
+
+
+`string`
+
+
+
+
+
+
+## issuer
+### Domain-name of the issuer of the reference, in reverse order
+
+Reversed DNS name for the broker, for example, example.com becomes com.example
+
+`issuer`
+* is optional
+* type: `string`
+* defined in this schema
+
+### issuer Type
+
+
+`string`
+
+
+All instances must conform to this regular expression 
+(test examples [here](https://regexr.com/?expression=%5E((%5Ba-zA-Z0-9%5D%7C%5Ba-zA-Z0-9%5D%5Ba-zA-Z0-9-%5D%5Ba-zA-Z0-9%5D).)(%5BA-Za-z0-9%5D%7C%5BA-Za-z0-9%5D%5BA-Za-z0-9-%5D*%5BA-Za-z0-9%5D))):
+```regex
+^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])
+```
+
+
+
+
+

--- a/schema/se/PrivateUnsecuredLoanApplicationCreated.yaml
+++ b/schema/se/PrivateUnsecuredLoanApplicationCreated.yaml
@@ -349,18 +349,11 @@ definitions:
 required:
   - application
   - dataProtectionContext
+  - brokerReference
 properties:
-  broker:
-    type: "string"
-    title: 'Domain-name of the broker, in reverse order'
-    description: "Reversed DNS name for the broker, for example, example.com becomes com.example"
-    pattern: "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])"
-
   brokerReference:
-    type: string
-    title: "Reference number for the broker"
-    description: "An arbitrary ID specified by the broker, must be unique per broker"
-
+    title: "A reference-id used by the broker"
+    "$ref": "https://open-broker.org/schema/v0/se/reference"
   dataProtectionContext:
     type: string
     title: "The data-protection context of the application"

--- a/schema/se/PrivateUnsecuredLoanDelayedProcessing.yaml
+++ b/schema/se/PrivateUnsecuredLoanDelayedProcessing.yaml
@@ -6,19 +6,12 @@ additionalProperties: false
 "$id": "https://open-broker.org/schema/v0/se/PrivateUnsecuredDelayedProcessing"
 "$schema": "http://json-schema.org/draft-06/schema#"
 required:
-  - broker
   - brokerReference
   - status
 properties:
-  broker:
-    type: "string"
-    title: 'Domain-name of the broker, in reverse order'
-    description: "Reversed DNS name for the broker, for example, example.com becomes com.example"
-    pattern: "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])"
   brokerReference:
-    type: "string"
-    minLength: 1
-    title: "Reference number for the broker"
+    title: "A reference-id used by the broker"
+    "$ref": "https://open-broker.org/schema/v0/se/reference"
   delayReason:
     type: "string"
     title: "the reason for the delay"

--- a/schema/se/PrivateUnsecuredLoanDisbursed.yaml
+++ b/schema/se/PrivateUnsecuredLoanDisbursed.yaml
@@ -7,20 +7,13 @@ additionalProperties: false
 "$id": "https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanDisbursed"
 "$schema": "http://json-schema.org/draft-06/schema#"
 required:
-  - broker
   - brokerReference
   - amountDisbursed
   - amountBrokered
 properties:
-  broker:
-    type: "string"
-    title: 'Domain-name of the broker, in reverse order'
-    description: "Reversed DNS name for the broker, for example, example.com becomes com.example"
-    pattern: "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])"
   brokerReference:
-    type: "string"
-    minLength: 1
-    title: "Reference number for the broker"
+    title: "A reference-id used by the broker"
+    "$ref": "https://open-broker.org/schema/v0/se/reference"
   amountDisbursed:
     type: "integer"
     minimum: 0

--- a/schema/se/PrivateUnsecuredLoanOffering.yaml
+++ b/schema/se/PrivateUnsecuredLoanOffering.yaml
@@ -141,18 +141,11 @@ definitions:
       loanInsuranceOffer:
         "$ref": "#/definitions/LoanInsuranceOffer"
 required:
-  - broker
   - brokerReference
   - offer
 properties:
-  broker:
-    type: "string"
-    title: 'Domain-name of the broker, in reverse order'
-    description: "Reversed DNS name for the broker, for example, example.com becomes com.example"
-    pattern: "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])"
   brokerReference:
-    type: "string"
-    minLength: 1
-    title: "Reference number for the broker"
+    title: "A reference-id used by the broker"
+    "$ref": "https://open-broker.org/schema/v0/se/reference"
   offer:
     "$ref": "#/definitions/Offer"

--- a/schema/se/PrivateUnsecuredLoanRejection.yaml
+++ b/schema/se/PrivateUnsecuredLoanRejection.yaml
@@ -6,15 +6,8 @@ additionalProperties: false
 "$id": "https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanRejection"
 "$schema": "http://json-schema.org/draft-06/schema#"
 required:
-  - broker
   - brokerReference
 properties:
-  broker:
-    type: "string"
-    title: 'Domain-name of the broker, in reverse order'
-    description: "Reversed DNS name for the broker, for example, example.com becomes com.example"
-    pattern: "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])"
   brokerReference:
-    type: "string"
-    minLength: 1
-    title: "Reference number for the broker"
+    title: "A reference-id used by the broker"
+    "$ref": "https://open-broker.org/schema/v0/se/reference"

--- a/schema/se/PrivateUnsecuredLoanStatusUpdated.yaml
+++ b/schema/se/PrivateUnsecuredLoanStatusUpdated.yaml
@@ -6,19 +6,12 @@ additionalProperties: false
 "$id": "https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanStatusUpdated"
 "$schema": "http://json-schema.org/draft-06/schema#"
 required:
-  - broker
   - brokerReference
   - status
 properties:
-  broker:
-    type: "string"
-    title: 'Domain-name of the broker, in reverse order'
-    description: "Reversed DNS name for the broker, for example, example.com becomes com.example"
-    pattern: "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])"
   brokerReference:
-    type: "string"
-    minLength: 1
-    title: "Reference number for the broker"
+    title: "A reference-id used by the broker"
+    "$ref": "https://open-broker.org/schema/v0/se/reference"
   status:
     type: "string"
     title: "the new status of the application"

--- a/schema/se/reference.yaml
+++ b/schema/se/reference.yaml
@@ -1,0 +1,22 @@
+"$id": "https://open-broker.org/schema/v0/se/reference"
+"$schema": "http://json-schema.org/draft-06/schema#"
+title: reference
+description: |
+  A reference used for identification of an event. Consisting of two
+  parts an issuer domain name of the form `com.example`, and an
+  arbitrary id string. The values, taken together must be unique.
+
+  In other words, the issuing organization can issue an ID once only.
+
+type: object
+additionalProperties: false
+properties:
+  issuer:
+    type: "string"
+    title: 'Domain-name of the issuer of the reference, in reverse order'
+    description: "Reversed DNS name for the broker, for example, example.com becomes com.example"
+    pattern: "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])"
+  id:
+    type: string
+    title: "Reference number for the broker"
+    description: "An arbitrary reference string that is unique"


### PR DESCRIPTION
The reference format consists of two parts a domain name and an arbitrary string. These form common object that is reusable and that should be a common component