### PR TITLE
Remove support for providerOfferReference

### DIFF
--- a/schema/se/PrivateUnsecuredLoanOfferAccepted.yaml
+++ b/schema/se/PrivateUnsecuredLoanOfferAccepted.yaml
@@ -6,9 +6,9 @@ additionalProperties: false
 "$id": "https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanOfferAccepted"
 "$schema": "http://json-schema.org/draft-06/schema#"
 required:
-  - providerOfferReference
+  - brokerReference
 properties:
-  providerOfferReference:
+  brokerReference:
     title: "The reference used for the offer being accepted"
     "$ref": "https://open-broker.org/schema/v0/se/reference"
 

--- a/schema/se/PrivateUnsecuredLoanOfferRejected.yaml
+++ b/schema/se/PrivateUnsecuredLoanOfferRejected.yaml
@@ -7,8 +7,8 @@ additionalProperties: false
 "$id": "https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanOfferRejected"
 "$schema": "http://json-schema.org/draft-06/schema#"
 required:
-  - providerOfferReference
+  - brokerReference
 properties:
-  providerOfferReference:
+  brokerReference:
     title: "The reference used for the offer being rejected"
     "$ref": "https://open-broker.org/schema/v0/se/reference"

--- a/schema/se/PrivateUnsecuredLoanOffering.yaml
+++ b/schema/se/PrivateUnsecuredLoanOffering.yaml
@@ -152,9 +152,6 @@ properties:
   brokerReference:
     title: "The reference used by the broker for the application resulting in this offer"
     "$ref": "https://open-broker.org/schema/v0/se/reference"
-  providerOfferReference:
-    title: "The reference used by the service provider for referring to this offer"
-    "$ref": "https://open-broker.org/schema/v0/se/reference"
 
   offer:
     "$ref": "#/definitions/Offer"


### PR DESCRIPTION
Only use the brokerReference in all events. Each reference should be suffieciently qualified and unique since each broker will have its unique `issuer` when creating a reference, thus, collision of IDs should not be possible and the offer provider should not have to create their own IDs that the broker must use.