### PR TITLE
Add field "creditNote"

### DIFF
--- a/schema/se/PrivateUnsecuredLoanApplicationCreated.yaml
+++ b/schema/se/PrivateUnsecuredLoanApplicationCreated.yaml
@@ -280,6 +280,12 @@ definitions:
         type: integer
         minimum: 0
         title: "Money paid for child-support each month"
+      creditNote:
+        type: boolean
+        title: "Applicant has a credit note"
+        description: |
+          Indicate whether an applicant has a credit note or not, due to a failure to 
+          pay an outstanding bill.
       housingType:
         type: string
         title: "Housing type for the applicant"


### PR DESCRIPTION
- The name of the field can be discussed. Unsure what the convention is here? "_paymentRemark_" seems also to occur.
- I did not mark this value as required, but given that _we_ will always (?) have this information about an applicant, maybe we could make it required? Or could this affect the adoption rate of Open Broker (I have a heard time seeing it would)?