### PR TITLE
Escape period in patterns

### DIFF
--- a/schema/se/PrivateUnsecuredLoanOffering.yaml
+++ b/schema/se/PrivateUnsecuredLoanOffering.yaml
@@ -42,7 +42,7 @@ definitions:
     properties:
       effectiveInterestRate:
         type: string
-        pattern: "^[0-9]+(.[0-9]+)?$"
+        pattern: "^[0-9]+(\.[0-9]+)?$"
         title: Effective interest rate (APR)
         description: |
           The effective annual interest rate of the loan
@@ -52,7 +52,7 @@ definitions:
           equal to `1.0`.
       nominalInterestRate:
         type: string
-        pattern: "^[0-9]+(.[0-9]+)?$"
+        pattern: "^[0-9]+(\.[0-9]+)?$"
         title: Nominal interest rate
         description: |
           The nominal annual interest rate of the loan


### PR DESCRIPTION
The change prevents the float regex from accepting:
1,5
1:5
1a5

And only accept this format:
1.5