### PR TITLE
Mortgage: Add "issuedFor" to Reference

### DIFF
--- a/se/Mortgage/schema/Reference.yaml
+++ b/se/Mortgage/schema/Reference.yaml
@@ -10,13 +10,18 @@ description: |
 
 type: object
 additionalProperties: false
+required:
+  - issuer
+  - id
 properties:
   issuer:
-    type: "string"
+    type: string
     title: 'Domain-name of the issuer of the reference, in reverse order'
     description: "Reversed DNS name for the broker, for example, example.com becomes com.example"
     pattern: "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])"
   id:
     type: string
     title: "Reference number for the broker"
-    description: "An arbitrary reference string that is unique"
+    description: |
+      An arbitrary reference string that is unique in the given namespace for
+      the issuer.

--- a/se/Mortgage/schema/Reference.yaml
+++ b/se/Mortgage/schema/Reference.yaml
@@ -2,22 +2,33 @@
 "$schema": "http://json-schema.org/draft-06/schema#"
 title: reference
 description: |
-  A reference used for identification of an event. Consisting of two
-  parts an issuer domain name of the form `com.example`, and an
-  arbitrary id string. The values, taken together must be unique.
-
-  In other words, the issuing organization can issue an ID once only.
+  A reference used for identification of an event. Consisting of three
+  parts;
+   - an "issuer" domain name of the form `com.example` identifying the issuer
+  of the reference (the broker)
+   - an "issued for" domain name of the form `com.example` identifying the
+  entity that the reference was issued for (the lender)
+  - an arbitrary id string.
+  The values, taken together must be unique. In other words,
+  the issuing organization can issue an ID once only.
 
 type: object
 additionalProperties: false
 required:
   - issuer
+  - issuedFor
   - id
 properties:
   issuer:
     type: string
     title: 'Domain-name of the issuer of the reference, in reverse order'
     description: "Reversed DNS name for the broker, for example, example.com becomes com.example"
+    pattern: "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])"
+  issuedFor:
+    type: string
+    title: 'Domain-name of the lender that the reference is issued for,
+     in reverse order'
+    description: "Reversed DNS name for the lender, for example, example.com becomes com.example"
     pattern: "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-][a-zA-Z0-9]).)([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])"
   id:
     type: string


### PR DESCRIPTION
I know this is a bit of a controversial topic, and it has been discussed before to some extent, but this addition has mostly been rejected before because for _PrivateUnsercuredLoan_ it came a bit too late in the process. And I feel now after using the _PrivateUnsercuredLoan_ specification that it adds quite a lot of complexity to *not* have it. There is a lot of extra code and that could potentially be dropped if the _Reference_ in the mortgage standard includes who the reference was issued for.