### PR TITLE
Make 'lenderName' required for existing loans

### DIFF
--- a/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
+++ b/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
@@ -93,8 +93,9 @@ definitions:
     required:
       - loanAmount
       - monthlyPayment
-      - existingLoanType
       - shouldRefinance
+      - existingLoanType
+      - lenderName
       - responsibility
     properties:
       loanAmount:


### PR DESCRIPTION
We collect the _lender name_ info from our customers existing loans. It is such a common value for the banks to want so it should be _required_ in the specification.