### PR TITLE
Mortgage SE: Fix incorrect value for required attribute: paymentRemarks -> paymentRemark

### DIFF
--- a/se/Mortgage/v0/schema/definitions/Applicant.yaml
+++ b/se/Mortgage/v0/schema/definitions/Applicant.yaml
@@ -14,7 +14,7 @@ required:
   - employmentStatusSinceYear
   - employmentStatusSinceMonth
   - dependentChildren
-  - paymentRemarks
+  - paymentRemark
   - housingType
   - monthlyRent
   - monthlyGrossIncome


### PR DESCRIPTION
The property name is already `paymentRemark`, but in the list of required properties it is still called `paymentRemarks` (note ending _s_). This PR fixed this issue.