### PR TITLE
Mortgage SE: List existing mortgages under existing loans

### DIFF
--- a/se/Mortgage/v0/example/MortgageApplicationCreated.json
+++ b/se/Mortgage/v0/example/MortgageApplicationCreated.json
@@ -86,18 +86,28 @@
                     "monthlyCost": 400,
                     "existingLoanType": "STUDENT_LOAN",
                     "responsibility": "MAIN_APPLICANT"
+                },
+                {
+                    "loanAmount": 1800000,
+                    "monthlyCost": 1700,
+                    "existingLoanType": "MORTGAGE",
+                    "responsibility": "MAIN_APPLICANT"
+                },
+                {
+                    "loanAmount": 300000,
+                    "monthlyCost": 700,
+                    "existingLoanType": "MORTGAGE",
+                    "responsibility": "MAIN_APPLICANT"
                 }
             ],
             "ownedProperties": [
                 {
                     "propertyType": "VACATION_HOME",
-                    "existingMortgage": 1300000,
                     "monthlyCost": 200,
                     "ownershipShare": 80
                 },
                 {
                     "propertyType": "APARTMENT",
-                    "existingMortgage": 1800000,
                     "monthlyCost": 2300,
                     "ownershipShare": 100
                 }

--- a/se/Mortgage/v0/schema/definitions/ExistingLoan.yaml
+++ b/se/Mortgage/v0/schema/definitions/ExistingLoan.yaml
@@ -26,6 +26,7 @@ properties:
       CREDIT_CARD: A credit-card
       STUDENT_LOAN: A student loan
       UNSECURED_LOAN: An unsecured loan, not falling into any of the other categories, for example a consumer loan.
+      MORTGAGE: A mortgage, where a house or other property is security for the loan
       OTHER: Any other debt not falling into any of the other categories.
     enum:
       - CAR_LOAN
@@ -33,6 +34,7 @@ properties:
       - CREDIT_CARD
       - STUDENT_LOAN
       - UNSECURED_LOAN
+      - MORTGAGE
       - OTHER
   responsibility:
     type: string

--- a/se/Mortgage/v0/schema/definitions/ExistingLoan.yaml
+++ b/se/Mortgage/v0/schema/definitions/ExistingLoan.yaml
@@ -2,7 +2,9 @@
 "$schema": "http://json-schema.org/draft-07/schema#"
 
 title: ExistingLoan
-description: Any existing loan that an applicant has
+description: |
+  Any existing loan that an applicant has, not including the mortgage
+  that will be refinanced
 type: object
 additionalProperties: false
 required:

--- a/se/Mortgage/v0/schema/definitions/OwnedProperty.yaml
+++ b/se/Mortgage/v0/schema/definitions/OwnedProperty.yaml
@@ -9,7 +9,6 @@ type: object
 additionalProperties: false
 required:
   - propertyType
-  - existingMortgage
   - monthlyCost
   - ownershipShare
 properties:
@@ -32,10 +31,6 @@ properties:
       OTHER: |
         Some other form of real-estate property that does not belong
         to any of the above categories
-  existingMortgage:
-    type: integer
-    min: 0
-    description: How mortgaged the property is, in SEK
   monthlyCost:
     type: integer
     min: 0


### PR DESCRIPTION
This will make it slightly less confusing, since we will keep all loans in one place regardless of whether they are mortgages or consumer loans. How ever, this does *only* apply to the mortgages not being refinanced. The mortgage being refinanced is still specified under refinancingProperty.