### PR TITLE
Adds fields to Loan Purpose (Private Unsecure Loans)

### DIFF
--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
@@ -70,6 +70,8 @@ definitions:
         'meta:enum':
           REFINANCE: Refinancing existing debt
           HOME_REMODELLING: Home remodelling or renovation
+          HOME_DOWNPAYMENT: To finance down payment for purchasing a home
+          DIVORCE_PROCEEDINGS: To finance costs related to divorce proceedings
           HEALTHCARE_EXPENSES: To finance health-care costs.
           EDUCATION: To finance education of some kind
           TRAVEL: To finance a vacation or other travel expenses
@@ -78,6 +80,8 @@ definitions:
         enum:
           - REFINANCE
           - HOME_REMODELLING
+          - HOME_DOWNPAYMENT
+          - DIVORCE_PROCEEDINGS
           - HEALTHCARE_EXPENSES
           - EDUCATION
           - TRAVEL

--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
@@ -70,9 +70,8 @@ definitions:
         'meta:enum':
           REFINANCE: Refinancing existing debt
           HOME_REMODELLING: Home remodelling or renovation
-          HOME_DOWNPAYMENT: To finance down payment for purchasing a home
-          DIVORCE_PROCEEDINGS: To finance costs related to divorce proceedings
           HEALTHCARE_EXPENSES: To finance health-care costs.
+          INVESTMENT: To finance an investment
           EDUCATION: To finance education of some kind
           TRAVEL: To finance a vacation or other travel expenses
           CAR: To finance the purchase of a car or similar
@@ -80,9 +79,8 @@ definitions:
         enum:
           - REFINANCE
           - HOME_REMODELLING
-          - HOME_DOWNPAYMENT
-          - DIVORCE_PROCEEDINGS
           - HEALTHCARE_EXPENSES
+          - INVESTMENT
           - EDUCATION
           - TRAVEL
           - CAR

--- a/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
+++ b/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
@@ -70,9 +70,7 @@ definitions:
         "meta:enum":
           REFINANCE: Refinancing existing debt
           HOME_REMODELLING: Home remodelling or renovation
-          HEALTHCARE_EXPENSES: To finance health-care costs.
-          DIVORCE_PROCEEDINGS: To finance costs relating to a divorce.
-          HOME_DOWNPAYMENT: To finance a downpayment for a loan
+          INVESTMENT: To finance an investment
           EDUCATION: To finance education of some kind
           TRAVEL: To finance a vacation or other travel expenses
           CAR: To finance the purchase of a car or similar
@@ -80,9 +78,7 @@ definitions:
         enum:
           - REFINANCE
           - HOME_REMODELLING
-          - HEALTHCARE_EXPENSES
-          - DIVORCE_PROCEEDINGS
-          - HOME_DOWNPAYMENT
+          - INVESTMENT
           - EDUCATION
           - TRAVEL
           - CAR

--- a/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
+++ b/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
@@ -70,6 +70,9 @@ definitions:
         "meta:enum":
           REFINANCE: Refinancing existing debt
           HOME_REMODELLING: Home remodelling or renovation
+          HEALTHCARE_EXPENSES: To finance health-care costs.
+          DIVORCE_PROCEEDINGS: To finance costs relating to a divorce.
+          HOME_DOWNPAYMENT: To finance a downpayment for a loan
           INVESTMENT: To finance an investment
           EDUCATION: To finance education of some kind
           TRAVEL: To finance a vacation or other travel expenses
@@ -78,6 +81,9 @@ definitions:
         enum:
           - REFINANCE
           - HOME_REMODELLING
+          - HEALTHCARE_EXPENSES
+          - DIVORCE_PROCEEDINGS
+          - HOME_DOWNPAYMENT
           - INVESTMENT
           - EDUCATION
           - TRAVEL


### PR DESCRIPTION
~~The suggestion is to add two more fields to blanco loans in Norway:~~

- ~~HOME_DOWNPAYMENT~~
- ~~DIVORCE_PROCEEDINGS~~

~~_Motivation:_~~
~~The honest motvation is that rickard has added them in frontend and i trust he got them from a valid source? Also, they feel very resonable to me at least.~~

---------------------------------------------------

**UPDATE**
Got info from ceo, these are the required fields for both sweden and norway Private Unsecure Loans:
- REFINANCE
- HOME_REMODELLING
- INVESTMENT
- EDUCATION
- TRAVEL
- CAR
- OTHER

If we were to include all and only these fields, it would mean removing existing fields. Since this specification is outside the scope of only our company, the suggestion is to not remove any fields, but only adding missing ones. 

Therefore, these would be the fields:
**SWEDEN:**
- REFINANCE
- HOME_REMODELLING
- HEALTHCARE_EXPENSES
- DIVORCE_PROCEEDINGS
- HOME_DOWNPAYMENT
- **INVESTMENT [new]**
- EDUCATION
- TRAVEL
- CAR
- OTHER

**NORWAY:**
- REFINANCE
- HOME_REMODELLING
- HEALTHCARE_EXPENSES
- **INVESTMENT [new]**
- EDUCATION
- TRAVEL
- CAR
- OTHER