### PR TITLE
Adds examples to PrivateUnsecuredLoan for Norway

### DIFF
--- a/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanApplicationCreated.json
+++ b/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanApplicationCreated.json
@@ -1,0 +1,96 @@
+{
+    "cloudEventsVersion" : "0.1",
+    "eventType" : "org.open-broker.v0.no.PrivateUnsecuredLoanApplicationCreated",
+    "eventTypeVersion" : "v0",
+    "source" : "/mycontext",
+    "eventID" : "C234-1234-1234",
+    "eventTime" : "2018-04-05T17:31:00Z",
+    "extensions" : {
+      "comExampleExtension" : "value"
+    },
+    "contentType" : "application/json",
+    "data": {
+		"application": {
+			"applicant": {
+
+				"ssn": "31128012345",
+				"phone": "+4740123456",
+				"secondaryPhone": [],
+				"emailAddress": "example@example.no",
+				"employmentStatus": "PRIVATE_SECTOR",
+                "employmentStatusSinceYear": 2010,
+                "employmentStatusSinceMonth": 12,
+                "employerName": "Example AB",
+                "employerPhone": "+4740123456",
+                "dependentChildren": 0,
+                "childSupportReceivedMonthly": null,
+                "rentReceivedMonthly": null,
+                "otherIncomeReceivedMonthly": null,
+                "childSupportPaidMonthly": null,
+                "paymentRemark": false,
+				"housingType": "LODGER",
+                "housingSinceYear": 2010,
+                "housingSinceMonth": 12,
+				"housingCostPerMonth": 3000,
+				"netMonthlyIncome": 10000,
+                "grossYearlyIncome": 160000,
+                "partnerYearlyIncome": 0,
+				"maritalStatus": "COHABITING",
+				"bankAccount": "12345678901",
+				"citizenships": [
+					"NO",
+                    "SE"
+				],
+				"livedInCountrySinceYear": 1980,
+                "countriesOfResidence": [
+					"NO"
+				],
+				"taxResidentOf": [
+					"SE"
+				],
+                "education": "UNIVERSITY_SHORT",
+
+				"tentativeAddress": {
+					"firstName": "Bjarne",
+					"lastName": "Bjarnesen",
+					"address": "Fjordgatan 1",
+					"postalCode": "1234",
+					"city": "Oslo"
+				}
+			},
+			"coApplicant": null,
+			"existingLoans": [
+				{
+					"loanAmount": 100000,
+					"monthlyPayment": 3000,
+					"refinanceAmount": 100000,
+					"lenderName": "Lender name",
+					"existingLoanType": "CAR_LOAN",
+					"responsibility": "SHARED",
+                    "lender": "Example Bank"
+				},
+				{
+					"loanAmount": 150000,
+					"monthlyPayment": 1000,
+					"lenderName": "Lender name",
+					"existingLoanType": "STUDENT_LOAN",
+					"responsibility": "MAIN_APPLICANT",
+                    "lender": "Norskbank"
+				}
+			],
+			"extensions": {
+			    "io.klira.someExtensionProperty": 42,
+				"io.klira.someOtherExtensionProperty": 10000
+			},
+			"loanAmount": 300000,
+			"loanPurpose": "HOME_REMODELLING",
+			"refinanceAmount": 100000,
+			"termMonths": 36
+		},
+		"brokerReference": {
+			"issuer": "io.klira",
+			"id": "1"
+		},
+		"dataProtectionContext": "FICTIONAL"
+	}
+}

--- a/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanContractSigned.json
+++ b/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanContractSigned.json
@@ -1,0 +1,18 @@
+{
+    "cloudEventsVersion" : "0.1",
+    "eventType" : "org.open-broker.v0.no.PrivateUnsecuredLoanContractSigned",
+    "eventTypeVersion" : "v0",
+    "source" : "/mycontext",
+    "eventID" : "C234-1234-1234",
+    "eventTime" : "2018-04-05T17:31:00Z",
+    "extensions" : {
+        "comExampleExtension" : "value"
+    },
+    "contentType" : "application/json",
+    "data": {
+        "brokerReference": {
+            "issuer": "io.klira",
+            "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a"
+        }
+    }
+}

--- a/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanDisbursed.json
+++ b/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanDisbursed.json
@@ -1,0 +1,20 @@
+{
+  "cloudEventsVersion" : "0.1",
+  "eventType" : "org.open-broker.v0.no.PrivateUnsecuredLoanDisbursed",
+  "eventTypeVersion" : "v0",
+  "source" : "/mycontext",
+  "eventID" : "C234-1234-1234",
+  "eventTime" : "2018-04-05T17:31:00Z",
+  "extensions" : {
+    "comExampleExtension" : "value"
+  },
+  "contentType" : "application/json",
+  "data": {
+    "brokerReference": {
+      "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
+      "issuer": "io.klira"
+    },
+	"amountBrokered": 150000,
+	"amountDisbursed": 150000
+  }
+}

--- a/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanMessage.json
+++ b/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanMessage.json
@@ -1,0 +1,20 @@
+{
+    "cloudEventsVersion" : "0.1",
+    "eventType" : "org.open-broker.v0.no.PrivateUnsecuredLoanMessage",
+    "eventTypeVersion" : "v0",
+    "source" : "/mycontext",
+    "eventID" : "C234-1234-1234",
+    "eventTime" : "2018-04-05T17:31:00Z",
+    "extensions" : {
+        "comExampleExtension" : "value"
+    },
+    "contentType" : "application/json",
+    "data": {
+        "brokerReference": {
+            "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
+            "issuer": "io.klira"
+        },
+        "message": "Application will be processed manually",
+        "requiresAction": false
+    }
+}

--- a/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOfferAccepted.json
+++ b/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOfferAccepted.json
@@ -1,0 +1,20 @@
+{
+  "cloudEventsVersion" : "0.1",
+  "eventType" : "org.open-broker.v0.no.PrivateUnsecuredLoanOfferAccepted",
+  "eventTypeVersion" : "v0",
+  "source" : "/mycontext",
+  "eventID" : "C234-1234-1234",
+  "eventTime" : "2018-04-05T17:31:00Z",
+  "extensions" : {
+    "comExampleExtension" : "value"
+  },
+  "contentType" : "application/json",
+  "data": {
+    "brokerReference": {
+      "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
+      "issuer": "io.klira"
+    },
+    "bankAccount": "12345678901",
+    "requestedCredit": 150000
+  }
+}

--- a/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOfferRejected.json
+++ b/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOfferRejected.json
@@ -1,0 +1,18 @@
+{
+  "cloudEventsVersion" : "0.1",
+  "eventType" : "org.open-broker.v0.no.PrivateUnsecuredLoanOfferRejected",
+  "eventTypeVersion" : "v0",
+  "source" : "/mycontext",
+  "eventID" : "C234-1234-1234",
+  "eventTime" : "2018-04-05T17:31:00Z",
+  "extensions" : {
+    "comExampleExtension" : "value"
+  },
+  "contentType" : "application/json",
+  "data": {
+    "brokerReference": {
+      "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
+      "issuer": "io.klira"
+    }
+  }
+}

--- a/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOffering.json
+++ b/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOffering.json
@@ -1,0 +1,36 @@
+{
+  "cloudEventsVersion": "0.1",
+  "eventType": "org.open-broker.v0.no.PrivateUnsecuredLoanOffering",
+  "eventTypeVersion": "v0",
+  "source": "/mycontext",
+  "eventID": "C234-1234-1234",
+  "eventTime": "2018-04-05T17:31:00Z",
+  "extensions": {
+    "comExampleExtension": "value"
+  },
+  "contentType": "application/json",
+  "data": {
+    "loanInsuranceOffer": {
+        "insuredAmount": 300000,
+        "monthlyPremium": 500
+    },
+    "offer": {
+        "effectiveInterestRate": "0.105",
+        "nominalInterestRate": "0.055",
+        "minOfferedCredit": 250000,
+        "offeredCredit": 300000,
+        "monthlyCost": 2000,
+        "maxOfferedCredit": 300000,
+        "mustRefinance": 100000,
+        "arrangementFee": 695,
+        "termFee": 500,
+        "invoiceFee": 50,
+        "termMonths": 84,
+        "amortizationType":"ANNUITY"
+    },
+    "brokerReference": {
+      "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
+      "issuer": "io.klira"
+    }
+  }
+}

--- a/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanRejection.json
+++ b/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanRejection.json
@@ -1,0 +1,18 @@
+{
+  "cloudEventsVersion" : "0.1",
+  "eventType" : "org.open-broker.v0.no.PrivateUnsecuredLoanRejection",
+  "eventTypeVersion" : "v0",
+  "source" : "/mycontext",
+  "eventID" : "C234-1234-1234",
+  "eventTime" : "2018-04-05T17:31:00Z",
+  "extensions" : {
+    "comExampleExtension" : "value"
+  },
+  "contentType" : "application/json",
+  "data": {
+    "brokerReference": {
+      "id": "14-0e2375ac997e17a54c1106a7e120fcf3b18a59de923bf4b5d14a61aea93a2a6a",
+      "issuer": "io.klira"
+    }
+  }
+}

--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
@@ -180,7 +180,7 @@ definitions:
       - dependentChildren
       - housingType
       - housingCostPerMonth
-      - monthlyIncome
+      - netMonthlyIncome
       - maritalStatus
       - citizenships
       - countriesOfResidence
@@ -338,11 +338,11 @@ definitions:
         minimum: 0
         examples:
         - 10000
-      monthlyIncome:
+      netMonthlyIncome:
         type: integer
         minimum: 0
         title: The monthly net (post-tax) income of the applicant
-      yearlyIncome:
+      grossYearlyIncome:
         type: integer
         minimum: 0
         title: The yearly gross (pre-tax) income of the applicant


### PR DESCRIPTION
It was lacking examples, so this PR includes examples for all schemas in norway->PrivateUnsecuredLoans

ALSO: i messed up in git, so it also contains a suggested update to changes "monthlyIncome" and yearlyIncome" to "netMonthlyIncome" and "grossYearlyIncome". Purpose of this update is to match the jvm naming, and reduce confusion.