### PR TITLE
Fix regex strings quotation

### DIFF
--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOffering.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOffering.yaml
@@ -41,7 +41,7 @@ definitions:
     properties:
       effectiveInterestRate:
         type: string
-        pattern: "^[0-9]+(\.[0-9]+)?$"
+        pattern: '^[0-9]+(\.[0-9]+)?$'
         title: Effective interest rate (APR)
         description: |
           The effective annual interest rate of the loan
@@ -51,7 +51,7 @@ definitions:
           equal to `1.0`.
       nominalInterestRate:
         type: string
-        pattern: "^[0-9]+(\.[0-9]+)?$"
+        pattern: '^[0-9]+(\.[0-9]+)?$'
         title: Nominal interest rate
         description: |
           The nominal annual interest rate of the loan

--- a/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOffering.yaml
+++ b/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOffering.yaml
@@ -42,7 +42,7 @@ definitions:
     properties:
       effectiveInterestRate:
         type: string
-        pattern: "^[0-9]+(\.[0-9]+)?$"
+        pattern: '^[0-9]+(\.[0-9]+)?$'
         title: Effective interest rate (APR)
         description: |
           The effective annual interest rate of the loan
@@ -52,7 +52,7 @@ definitions:
           equal to `1.0`.
       nominalInterestRate:
         type: string
-        pattern: "^[0-9]+(\.[0-9]+)?$"
+        pattern: '^[0-9]+(\.[0-9]+)?$'
         title: Nominal interest rate
         description: |
           The nominal annual interest rate of the loan


### PR DESCRIPTION
In YAML if backslash is used in double quoted string it should be escaped
 with `\` (`\\`). Previous values broke build_schema script. In single quotes
only single quotation needs to be escaped with single quote.

This change fixes build issue and keeps regexes unchanged.