### PR TITLE
Add email offeraccepted

### DIFF
--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanMessage.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanMessage.yaml
@@ -10,7 +10,7 @@ additionalProperties: false
 required:
   - brokerReference
   - message
-  - requriesAction
+  - requiresAction
 properties:
   brokerReference:
     title: A reference-id used by the broker

--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
@@ -10,17 +10,17 @@ required:
   - brokerReference
 properties:
   brokerReference:
-    title: The reference used for the offer being accepted
+    title: The reference used by the broker for the application resulting in this offer
     '$ref': 'https://open-broker.org/schema/v0/no/reference'
   offerId:
-    title: A reference used for identifying the offer that is being accepted
+    title: A reference used for identifying the offer being accepted
     $ref: 'http://open-broker.org/no/PrivateUnsecuredLoan/v0/schema#/definitions/reference'
   bankAccount:
     type: string
     title: The bank acccount to pay out the money to
     description: |
       The broker may include an updated bank account for the
-      applicant. The service provider may ignore this updated field if
+      applicant. The service-provider may ignore this updated field if
       not supported.
     pattern: '^[0-9]{11}$'
     minLength: 11
@@ -31,8 +31,8 @@ properties:
     title:
       Amount of credit requested by the customer
     description: |
-      The amount of credit requested by the user. A service-provider
-      use this value to set the size of the actual loan within the
+      The amount of credit requested by the customer. A service-provider
+      uses this value to set the size of the actual loan within the
       bounds set in the loan offer. If this field is missing or
       outside the bounds set in the loan offer, service-providers
       should use the `offeredCredit` value.
@@ -40,7 +40,6 @@ properties:
     type: string
     format: email
     title: Email address of the applicant
-
   emailAddressCoapplicant:
     type: string
     format: email

--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
@@ -36,3 +36,12 @@ properties:
       bounds set in the loan offer. If this field is missing or
       outside the bounds set in the loan offer, service-providers
       should use the `offeredCredit` value.
+  emailAddress:
+    type: string
+    format: email
+    title: Email address of the applicant
+
+  emailAddressCoapplicant:
+    type: string
+    format: email
+    title: Email address of the coapplicant

--- a/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanDelayedProcessing.yaml
+++ b/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanDelayedProcessing.yaml
@@ -3,7 +3,7 @@ description: |
   An event indicating that processing of the application is delayed
 type: object
 additionalProperties: false
-"$id": "https://open-broker.org/schema/v0/se/PrivateUnsecuredDelayedProcessing"
+"$id": "https://open-broker.org/schema/v0/se/PrivateUnsecuredLoanDelayedProcessing"
 "$schema": "http://json-schema.org/draft-06/schema#"
 required:
   - brokerReference

--- a/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanMessage.yaml
+++ b/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanMessage.yaml
@@ -10,7 +10,7 @@ additionalProperties: false
 required:
   - brokerReference
   - message
-  - requriesAction
+  - requiresAction
 properties:
   brokerReference:
     title: A reference-id used by the broker

--- a/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
+++ b/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
@@ -10,15 +10,15 @@ required:
   - brokerReference
 properties:
   brokerReference:
-    title: The reference used for the offer being accepted
+    title: The reference used by the broker for the application resulting in this offer
     "$ref": "https://open-broker.org/schema/v0/se/reference"
 
   bankAccount:
     title: The bank account to pay out the money to
     description: |
       The broker may include an updated bank account for the
-      applicant. The service provider may ignore this updated field if
-      not unsupported.
+      applicant. The service-provider may ignore this updated field if
+      not supported.
     '$ref': "https://open-broker.org/schema/v0/se/BankAccount"
 
   requestedCredit:
@@ -27,14 +27,14 @@ properties:
     title:
       Amount of credit requested by the customer
     description: |
-      The amount of credit requested by the user. A service-provider
-      use this value to set the size of the actual loan within the
+      The amount of credit requested by the customer. A service-provider
+      uses this value to set the size of the actual loan within the
       bounds set in the loan offer. If this field is missing or
       outside the bounds set in the loan offer, service-providers
       should use the `offeredCredit` value.
 
   offerId:
-    title: A reference used for identifying this particular offer
+    title: A reference used for identifying the offer being accepted
     "$ref": "https://open-broker.org/schema/v0/se/reference"
 
   emailAddress:

--- a/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
+++ b/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
@@ -36,3 +36,13 @@ properties:
   offerId:
     title: A reference used for identifying this particular offer
     "$ref": "https://open-broker.org/schema/v0/se/reference"
+
+  emailAddress:
+    type: string
+    format: email
+    title: Email address of the applicant
+
+  emailAddressCoapplicant:
+    type: string
+    format: email
+    title: Email address of the coapplicant


### PR DESCRIPTION
Add opportunity to send an email address in OfferAccepted cloud event. It is useful for cases when a service-provider requires a valid customer's email for accepting their offer.