### PR TITLE
Add ssn offeraccepted

### DIFF
--- a/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanApplicationCreated.json
+++ b/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanApplicationCreated.json
@@ -12,7 +12,7 @@
     "data": {
 		"application": {
 			"applicant": {
-				"ssn": "31128012345",
+				"ssn": "11111111111",
 				"phone": "+4740123456",
 				"secondaryPhone": [],
 				"emailAddress": "example@example.no",

--- a/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOfferAccepted.json
+++ b/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOfferAccepted.json
@@ -16,6 +16,8 @@
         },
         "bankAccount": "12345678901",
         "requestedCredit": 150000,
+        "ssn": "11111111111",
+        "ssnCoapplicant": null,
         "emailAddress": "test@test.se",
         "emailAddressCoapplicant": null
     }

--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
@@ -196,7 +196,7 @@ definitions:
         minLength: 11
         maxLength: 11
         examples:
-        - '31128012345'
+        - '11111111111'
       phone:
         type: string
         title: Phone number to the applicant

--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
@@ -36,6 +36,24 @@ properties:
       bounds set in the loan offer. If this field is missing or
       outside the bounds set in the loan offer, service-providers
       should use the `offeredCredit` value.
+  ssn:
+    type: string
+    title: 11-digit Social Security Number (no. Fodselsnummer)
+    description: A Norweigian Social Security number in 11-digit format DDMMYYXXXXX
+    pattern: '^[0-9]{11}$'
+    minLength: 11
+    maxLength: 11
+    examples:
+      - '11111111111'
+  ssnCoapplicant:
+    type: string
+    title: 11-digit Social Security Number (no. Fodselsnummer)
+    description: A Norweigian Social Security number in 11-digit format DDMMYYXXXXX
+    pattern: '^[0-9]{11}$'
+    minLength: 11
+    maxLength: 11
+    examples:
+      - '11111111111'
   emailAddress:
     type: string
     format: email

--- a/se/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanApplicationCreated.json
+++ b/se/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanApplicationCreated.json
@@ -19,8 +19,8 @@
 				"employmentStatus": "FULL_TIME",
 				"employmentStatusSinceYear": 2017,
 				"employmentStatusSinceMonth": 2,
-                "employmentStatusUntilYear": null,
-                "employmentStatusUntilMonth": null,
+				"employmentStatusUntilYear": null,
+				"employmentStatusUntilMonth": null,
 				"dependentChildren": 0,
 				"housingType": "RENTED",
 				"housingCostPerMonth": 3000,
@@ -50,7 +50,7 @@
 					"loanAmount": 10000,
 					"monthlyPayment": 800,
 					"shouldRefinance": true,
-                    "refinanceAmount": 10000,
+					"refinanceAmount": 10000,
 					"existingLoanType": "CREDIT_CARD",
 					"responsibility": "MAIN_APPLICANT"
 				},
@@ -58,7 +58,7 @@
 					"loanAmount": 15000,
 					"monthlyPayment": 560,
 					"shouldRefinance": false,
-                    "refinanceAmount": 0,
+					"refinanceAmount": 0,
 					"existingLoanType": "CAR_LOAN",
 					"responsibility": "SHARED"
 				}

--- a/se/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanApplicationCreated.json
+++ b/se/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanApplicationCreated.json
@@ -12,7 +12,7 @@
     "data": {
 		"application": {
 			"applicant": {
-				"ssn": "198712160000",
+				"ssn": "191111111111",
 				"phone": "+46705431052",
 				"secondaryPhone": [],
 				"emailAddress": "anton@zensum.se",

--- a/se/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOfferAccepted.json
+++ b/se/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOfferAccepted.json
@@ -24,6 +24,8 @@
             "bankName": "Nordea"
         },
         "requestedCredit": 25000,
+        "ssn": "191111111111",
+        "ssnCoapplicant": null,
         "emailAddress": "test@test.se",
         "emailAddressCoapplicant": null
     }

--- a/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
+++ b/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
@@ -206,7 +206,7 @@ definitions:
         minLength: 12
         maxLength: 12
         examples:
-        - "195911057916"
+        - "191111111111"
       phone:
         type: string
         title: Phone number to the applicant

--- a/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
+++ b/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
@@ -37,6 +37,26 @@ properties:
     title: A reference used for identifying the offer being accepted
     "$ref": "https://open-broker.org/schema/v0/se/reference"
 
+  ssn:
+    type: string
+    title: 12-digit Social Security Number (sv. Personnr)
+    description: A Swedish Social Security number in 12-digit format YYYYMMDDXXXX
+    pattern: '^[0-9]{12}$'
+    minLength: 12
+    maxLength: 12
+    examples:
+      - "191111111111"
+
+  ssnCoapplicant:
+    type: string
+    title: 12-digit Social Security Number (sv. Personnr)
+    description: A Swedish Social Security number in 12-digit format YYYYMMDDXXXX
+    pattern: '^[0-9]{12}$'
+    minLength: 12
+    maxLength: 12
+    examples:
+      - "191111111111"
+
   emailAddress:
     type: string
     format: email


### PR DESCRIPTION
We received a requirement to add properties "ssn" and "ssnCoapplicant" to PrivateUnsecuredLoanOfferAccepted event for SE and NO.