### PR TITLE
Add property "termMonths" to OfferAccepted event

### DIFF
--- a/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOfferAccepted.json
+++ b/no/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOfferAccepted.json
@@ -16,6 +16,7 @@
         },
         "bankAccount": "12345678901",
         "requestedCredit": 150000,
+        "termMonths": 84,
         "ssn": "11111111111",
         "emailAddress": "test@test.se"
     }

--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
@@ -36,6 +36,12 @@ properties:
       bounds set in the loan offer. If this field is missing or
       outside the bounds set in the loan offer, service-providers
       should use the `offeredCredit` value.
+  termMonths:
+    type: integer
+    minimum: 1
+    title: Number of monthly terms
+    description: |
+      The number of month-terms to payback the loan.
   ssn:
     type: string
     title: 11-digit Social Security Number (no. Fodselsnummer)

--- a/se/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOfferAccepted.json
+++ b/se/PrivateUnsecuredLoan/example/PrivateUnsecuredLoanOfferAccepted.json
@@ -24,6 +24,7 @@
             "bankName": "Nordea"
         },
         "requestedCredit": 25000,
+        "termMonths": 84,
         "ssn": "191111111111",
         "emailAddress": "test@test.se"
     }

--- a/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
+++ b/se/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
@@ -33,6 +33,13 @@ properties:
       outside the bounds set in the loan offer, service-providers
       should use the `offeredCredit` value.
 
+  termMonths:
+    type: integer
+    minimum: 1
+    title: Number of monthly terms
+    description: |
+      The number of month-terms to payback the loan.
+
   offerId:
     title: A reference used for identifying the offer being accepted
     "$ref": "https://open-broker.org/schema/v0/se/reference"


### PR DESCRIPTION
Adding a property `termMonths` to event `PrivateUnsecuredLoanOfferAccepted` for both Sweden and Norway. The requirement is based on specifications from our partners that we need to comply to. 