### PR TITLE
fix: quote bare YAML `null` in NO PUL JSON-Schema `type` fields

### DIFF
--- a/no/PrivateUnsecuredLoan/schema/CreditCardApplicationCreated.yaml
+++ b/no/PrivateUnsecuredLoan/schema/CreditCardApplicationCreated.yaml
@@ -37,7 +37,7 @@ definitions:
         description: The primary applicant to the loan
       coApplicant:
         oneOf:
-          - type: null
+          - type: 'null'
           - '$ref': '#/definitions/applicant'
             '$linkVal': applicant
         title: Co-applicant
@@ -136,7 +136,7 @@ definitions:
         minLength: 1
       careOf:
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             minLength: 1
   applicant:
@@ -248,14 +248,14 @@ definitions:
       employerName:
         title: The company name of the employer
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             examples:
               - Example AB
       employerPhone:
         title: The phone number of the employer
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             pattern: '^\+[1-9][0-9]{1,14}$'
             examples:
@@ -319,7 +319,7 @@ definitions:
             maximum: 3000
             examples:
               - 2010
-          - type: null
+          - type: 'null'
       housingSinceMonth:
         title: Month in which the applicant entered into his or her current housing
         oneOf:
@@ -328,7 +328,7 @@ definitions:
             maximum: 12
             examples:
               - 12
-          - type: null
+          - type: 'null'
       housingCostPerMonth:
         type: integer
         title: Housing-related costs per month
@@ -347,7 +347,7 @@ definitions:
       partnerGrossYearlyIncome:
         title: The yearly gross (pre-tax) income of the applicant's partner
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 0
       maritalStatus:
@@ -368,7 +368,7 @@ definitions:
       bankAccount:
         title: Applicant's bank account number
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             pattern: '^[0-9]{11}$'
             minLength: 11
@@ -380,7 +380,7 @@ definitions:
       livedInCountrySinceYear:
         title: Year in which the applicant started living in the country
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1900
             maximum: 3000
@@ -389,19 +389,19 @@ definitions:
       countriesOfResidence:
         title: Countries that the applicant is a resident of
         oneOf:
-          - type: null
+          - type: 'null'
           - '$ref': '#/definitions/countryCodeArray'
             '$linkVal': countryCodeArray
       taxResidentOf:
         title: Countries that the applicant is a tax resident of
         oneOf:
-          - type: null
+          - type: 'null'
           - '$ref': '#/definitions/countryCodeArray'
             '$linkVal': countryCodeArray
       education:
         title: The highest education level of the applicant
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             'meta:enum':
               PRIMARY_SCHOOL: Completed the obligatory first stage of formal education (no. Grunnskole)
@@ -419,7 +419,7 @@ definitions:
           All actors are expected to perform proper due diligence in
           establishing the identity of the applicant
         oneOf:
-          - type: null
+          - type: 'null'
           - '$ref': '#/definitions/address'
             '$linkVal': address
 required:

--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanApplicationCreated.yaml
@@ -37,7 +37,7 @@ definitions:
           - 24
       refinanceAmount:
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             examples:
               - 25000
@@ -54,7 +54,7 @@ definitions:
         description: The primary applicant to the loan
       coApplicant:
         oneOf:
-          - type: null
+          - type: 'null'
           - '$ref': '#/definitions/applicant'
             '$linkVal': applicant
         title: Co-applicant
@@ -123,7 +123,7 @@ definitions:
           with floating-point numbers. The nominal interest rate of 15% would be written as `0.15`,
           and 100% as `1.0`.
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             pattern: '^(0\.[0-9]+|1\.0+)$'
             examples:
@@ -134,7 +134,7 @@ definitions:
         description: |
             The number of months required to pay back the loan.
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1
       monthlyPayment:
@@ -207,7 +207,7 @@ definitions:
         type: string
       careOf:
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             minLength: 1
   applicant:
@@ -244,7 +244,7 @@ definitions:
         description: "ID of the customer (unique per ssn)"
       phone:
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             pattern: '^\+[1-9][0-9]{1,14}$'
             examples:
@@ -252,7 +252,7 @@ definitions:
         title: Phone number to the applicant
       secondaryPhone:
         oneOf:
-          - type: null
+          - type: 'null'
           - type: array
             items:
               type: string
@@ -260,7 +260,7 @@ definitions:
         title: List of alternate phone numbers
       emailAddress:
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             format: email
         title: Email address to the applicant
@@ -314,7 +314,7 @@ definitions:
       employmentStatusUntilYear:
         title: Year in which the applicant ended his or her current employment status (for temporary employment)
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1900
             maximum: 3000
@@ -323,7 +323,7 @@ definitions:
       employmentStatusUntilMonth:
         title: Month in which the applicant ended his or her current employment status (for temporary employment)
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1
             maximum: 12
@@ -332,14 +332,14 @@ definitions:
       employerName:
         title: The company name of the employer
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             examples:
               - Example AB
       employerPhone:
         title: The phone number of the employer
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             pattern: '^\+[1-9][0-9]{1,14}$'
             examples:
@@ -355,25 +355,25 @@ definitions:
         maximum: 15
       childSupportReceivedMonthly:
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 0
         title: Money received for child-support each month
       rentReceivedMonthly:
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 0
         title: Money received for rent each month
       otherIncomeReceivedMonthly:
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 0
         title: Money received each month for categories outside child-support and rent
       childSupportPaidMonthly:
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 0
         title: Money paid for child-support each month
@@ -406,7 +406,7 @@ definitions:
       housingSinceYear:
         title: Year in which the applicant entered into his or her current housing
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1900
             maximum: 3000
@@ -415,7 +415,7 @@ definitions:
       housingSinceMonth:
         title: Month in which the applicant entered into his or her current housing
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1
             maximum: 12
@@ -430,7 +430,7 @@ definitions:
           - 10000
       netMonthlyIncome:
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 0
         title: The monthly net (post-tax) income of the applicant
@@ -440,7 +440,7 @@ definitions:
         title: The yearly gross (pre-tax) income of the applicant
       partnerGrossYearlyIncome:
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 0
         title: The yearly gross (pre-tax) income of the applicant's partner
@@ -462,7 +462,7 @@ definitions:
       bankAccount:
         title: Applicant's bank account number
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             pattern: '^[0-9]{11}$'
             minLength: 11
@@ -474,7 +474,7 @@ definitions:
       livedInCountrySinceYear:
         title: Year in which the applicant started living in the country
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1900
             maximum: 3000
@@ -491,7 +491,7 @@ definitions:
       education:
         title: The highest education level of the applicant
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             'meta:enum':
               PRIMARY_SCHOOL: Completed the obligatory first stage of formal education (no. Grunnskole)
@@ -509,7 +509,7 @@ definitions:
           All actors are expected to perform proper due diligence in
           establishing the identity of the applicant
         oneOf:
-          - type: null
+          - type: 'null'
           - '$ref': '#/definitions/address'
             '$linkVal': address
 required:

--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferAccepted.yaml
@@ -14,12 +14,12 @@ properties:
     '$ref': 'https://open-broker.org/schema/v0/no/reference'
   offerId:
     oneOf:
-      - type: null
+      - type: 'null'
       - '$ref': 'http://open-broker.org/no/PrivateUnsecuredLoan/v0/schema#/definitions/reference'
     title: A reference used for identifying the offer being accepted
   bankAccount:
     oneOf:
-      - type: null
+      - type: 'null'
       - type: string
         pattern: '^[0-9]{11}$'
         minLength: 11
@@ -32,7 +32,7 @@ properties:
       not supported.
   requestedCredit:
     oneOf:
-      - type: null
+      - type: 'null'
       - type: integer
         minimum: 0
     title:
@@ -45,7 +45,7 @@ properties:
       should use the `offeredCredit` value.
   termMonths:
     oneOf:
-      - type: null
+      - type: 'null'
       - type: integer
         minimum: 1
     title: Number of monthly terms
@@ -53,7 +53,7 @@ properties:
       The number of month-terms to payback the loan.
   ssn:
     oneOf:
-      - type: null
+      - type: 'null'
       - type: string
         pattern: '^[0-9]{11}$'
         minLength: 11
@@ -64,7 +64,7 @@ properties:
     description: A Norweigian Social Security number in 11-digit format DDMMYYXXXXX
   ssnCoapplicant:
     oneOf:
-      - type: null
+      - type: 'null'
       - type: string
         pattern: '^[0-9]{11}$'
         minLength: 11
@@ -75,13 +75,13 @@ properties:
     description: A Norweigian Social Security number in 11-digit format DDMMYYXXXXX
   emailAddress:
     oneOf:
-      - type: null
+      - type: 'null'
       - type: string
         format: email
     title: Email address of the applicant
   emailAddressCoapplicant:
     oneOf:
-      - type: null
+      - type: 'null'
       - type: string
         format: email
     title: Email address of the coapplicant

--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferRejected.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOfferRejected.yaml
@@ -15,5 +15,5 @@ properties:
   offerId:
     title: A reference used for identifying the offer being rejected
     oneOf:
-      - type: null
+      - type: 'null'
       - '$ref': 'http://open-broker.org/no/PrivateUnsecuredLoan/v0/schema#/definitions/reference'

--- a/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOffering.yaml
+++ b/no/PrivateUnsecuredLoan/schema/PrivateUnsecuredLoanOffering.yaml
@@ -68,7 +68,7 @@ definitions:
           offeredCredit. Indicating that this is the only possible
           amount offered.
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1
       offeredCredit:
@@ -87,7 +87,7 @@ definitions:
         description: |
           The minimum amount the customer must pay on the credit each month.
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1
       monthlyCost:
@@ -96,7 +96,7 @@ definitions:
           The average monthly cost of the loan given `offeredCredit`,
           `termMonths` and `effectiveInterestRate`.
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1
       maxOfferedCredit:
@@ -108,7 +108,7 @@ definitions:
           offeredCredit. Indicating that this is the only possible
           amount offered.
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1
       mustRefinance:
@@ -117,7 +117,7 @@ definitions:
           Amount the customer must use to refinance other loans.
           Use zero to indicate that no refinancing is required.
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1
       totalRepaymentAmount:
@@ -125,7 +125,7 @@ definitions:
         description: |
           Total amount that should be paid to lender over the length of the loan.
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1
       arrangementFee:
@@ -162,14 +162,14 @@ definitions:
           The number of month-terms required to payback the loan at
           the offered interest and offered amount.
         oneOf:
-          - type: null
+          - type: 'null'
           - type: integer
             minimum: 1
       amortizationType:
         title: Type of amortization plan
         description: Decides in which manner the loan is amortized
         oneOf:
-          - type: null
+          - type: 'null'
           - type: string
             'meta:enum':
               ANNUITY: |
@@ -185,7 +185,7 @@ definitions:
         title: Signing URL
         description: URL for signing the contract
         anyOf:
-          - type: null
+          - type: 'null'
           - type: string
             format: uri
 required:
@@ -198,11 +198,11 @@ properties:
   offerId:
     title: A reference used for identifying this particular offer
     oneOf:
-      - type: null
+      - type: 'null'
       - '$ref': 'https://open-broker.org/schema/v0/no/reference'
   offer:
     '$ref': '#/definitions/offer'
   loanInsuranceOffer:
     oneOf:
-      - type: null
+      - type: 'null'
       - '$ref': '#/definitions/loanInsuranceOffer'


### PR DESCRIPTION
The NO PrivateUnsecuredLoan schemas used:

    oneOf:
      - type: null
      - type: integer

The bare YAML `null` is parsed as the null value and serialized to JSON `null`, but JSON Schema requires `type` to be a string (or array of strings). The string `"null"` is what denotes the null type, so the YAML must quote it:

    oneOf:
      - type: 'null'
      - type: integer

Without the quotes the metaschema check fails with:

    None is not one of ['array', 'boolean', 'integer', 'null', 'number',
    'object', 'string']

which surfaced as a `test_all_examples_except_mortgage` failure on every NO PUL example whose schema referenced an affected property (e.g. `refinanceAmount`, `remainingTerms`).

Quoted `null` in 57 occurrences across:
- PrivateUnsecuredLoanApplicationCreated.yaml
- PrivateUnsecuredLoanOffering.yaml
- PrivateUnsecuredLoanOfferAccepted.yaml
- PrivateUnsecuredLoanOfferRejected.yaml
- CreditCardApplicationCreated.yaml